### PR TITLE
Refactor/use oid4cv core

### DIFF
--- a/lib/endpoint/processRequest.ts
+++ b/lib/endpoint/processRequest.ts
@@ -15,7 +15,7 @@
  * License.
  */
 
-import { runAsyncCatching } from 'au3te-ts-common/utils';
+import { runAsyncCatching } from 'oid4vc-core/utils';
 import { ToApiRequest } from './toApiRequest';
 import { Handle } from '../handler/handle';
 import * as responseFactory from '../utils/responseFactory';

--- a/lib/endpoint/service-configuration/toApiRequest.ts
+++ b/lib/endpoint/service-configuration/toApiRequest.ts
@@ -22,11 +22,11 @@ export const createToApiRequest =
   (): ToApiRequest<ServiceConfigurationRequest> =>
   async (request: Request): Promise<ServiceConfigurationRequest> => {
     const searchParams = new URL(request.url).searchParams;
-    const { pretty, patch } =
-      searchParams.get('pretty') === 'true'
-        ? { pretty: true, patch: searchParams.get('patch') }
-        : { pretty: false, patch: searchParams.get('patch') };
-    const apiRequest: ServiceConfigurationRequest = { pretty, patch };
+    const pretty = Boolean(searchParams.get('pretty'));
+    const patch = searchParams.get('patch');
+    const apiRequest: ServiceConfigurationRequest = patch
+      ? { pretty, patch }
+      : { pretty };
 
     return apiRequest;
   };

--- a/lib/handler/handle.ts
+++ b/lib/handler/handle.ts
@@ -15,7 +15,7 @@
  * License.
  */
 
-import { runAsyncCatching } from 'au3te-ts-common/utils';
+import { runAsyncCatching } from 'oid4vc-core/utils';
 import { ProcessApiRequest } from 'au3te-ts-common/handler';
 import { ProcessApiResponse } from './processApiResponse';
 import { RecoverResponseResult } from './recoverResponseResult';

--- a/lib/handler/recoverResponseResult.spec.ts
+++ b/lib/handler/recoverResponseResult.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { Result } from 'au3te-ts-common/utils';
+import { Result } from 'oid4vc-core/utils';
 import { ResponseError } from './ResponseError';
 import * as responseFactory from '../utils/responseFactory';
 import { createRecoverResponseResult } from './recoverResponseResult';

--- a/lib/handler/recoverResponseResult.ts
+++ b/lib/handler/recoverResponseResult.ts
@@ -15,7 +15,7 @@
  * License.
  */
 
-import { Result } from 'au3te-ts-common/utils';
+import { Result } from 'oid4vc-core/utils';
 import { ResponseError } from './ResponseError';
 import * as responseFactory from '../utils/responseFactory';
 import { ProcessError } from 'au3te-ts-common/handler';


### PR DESCRIPTION
## Changes

- Use result and errorUtils from [oid4vc-core/utils](https://github.com/dentsusoken/oid4vc-core/tree/main/lib/utils) package instead of u3te-ts-common/utils package